### PR TITLE
Update sondovac_part_a.sh

### DIFF
--- a/sondovac_part_a.sh
+++ b/sondovac_part_a.sh
@@ -401,7 +401,12 @@ echo
 
 # Make a list of these unique transcripts (names and sequences) and convert this file to FASTA
 echo "Making list of unique transcripts"
-cut -f 10 "${BLATOUT}" | uniq -c | awk '{if($1==1){print $0}}' | awk '{print $2}' | awk '{printf "%012d\n", $0;}' > "${UNIQUELIST}" || {
+{ 
+	cut -f 10 "${BLATOUT}" | uniq -c | awk '{if($1==1){print $0}}' | awk '{print $2}' | awk '{printf "%012d\n", $0;}' > QUNIQUELIST
+  	cut -f 14 "${BLATOUT}" | sort | uniq -c | awk '{if($1>1){print $0}}' | awk '{print $2}' | awk '{printf "%012d\n", $0;}' > TUNIQUELIST
+ 	grep -f TUNIQUELIST -v QUNIQUELIST > "${UNIQUELIST}" 
+	rm QUNIQUELIST TUNIQUELISTDD
+ } || {
 	echo
 	echo "Error! Making list of unique transcripts failed. Aborting. Check if files ${BLATOUT} and ${INPUTFILE} are correct."
 	echo


### PR DESCRIPTION
Sometimes happens, that Query is similar only to Query, but Target is similar to multiple queries, including the Query. Included rows ensure removing such  "backward similarities".
Check IDs: 
313
353 
38753

These "backward similarities" were found in 3.13% of IDs from $UNIQUELIST, extracted from the attached file.
[Eche_v2.0_transcripts.1line.noChl.VZ.blat_unique_transcripts.ods](https://github.com/V-Z/sondovac/files/14313425/Eche_v2.0_transcripts.1line.noChl.VZ.blat_unique_transcripts.ods)
